### PR TITLE
Add benchmarking documentation for lanec1

### DIFF
--- a/docs/source/advanced/benchmarking.md
+++ b/docs/source/advanced/benchmarking.md
@@ -1,0 +1,207 @@
+# Benchmarking the Lane Cluster
+
+This page documents a systematic benchmark of the Lane Cluster (`lanec1`) across two core computational biology workloads: matrix multiplication and biological sequence alignment. The goal is to characterize the computational limits of the node so that researchers can make informed decisions about which workloads are feasible on `lanec1` and when to use a more powerful resource such as Bridge2.
+
+The benchmarks cover two core computational biology workloads — matrix multiplication and sequence alignment — and were run on `lanec1` (Intel Xeon E5620, 8 cores @ 2.4 GHz, 23.4 GB RAM, CentOS 7) using Python 3.6.4 installed via the system module (`module load python36`).
+
+---
+
+## Node Specifications
+
+| Component | Details |
+|---|---|
+| **Hostname** | lanec1.compbio.cs.cmu.edu |
+| **OS** | CentOS 7 (kernel 3.10.0) |
+| **CPU** | Intel Xeon E5620 @ 2.40 GHz |
+| **Sockets / Cores** | 2 sockets × 4 cores = 8 cores total |
+| **RAM** | 23.4 GB total / ~18 GB available |
+| **L3 Cache** | 12 MB |
+| **Python** | 3.6.4 (via `module load python36`) |
+| **GLIBC** | 2.17 |
+
+> **Note:** `lanec1` runs GLIBC 2.17, which is incompatible with modern Conda/Miniconda installers (require GLIBC ≥ 2.28). Package installation was done via `pip install --user` instead.
+
+---
+
+## Part 1: Matrix Multiplication
+
+Matrix multiplication is a core operation in many computational biology workflows, including dimensionality reduction (PCA), machine learning, and coexpression analysis. This benchmark determines the maximum matrix size that `lanec1` can multiply in memory using NumPy.
+
+Multiplying two N×N float64 matrices requires approximately 3 × N² × 8 bytes of RAM simultaneously (two input matrices + one output matrix).
+
+### Environment Setup
+
+```bash
+module load python36
+pip3 install numpy --user
+python3 -c "import numpy; print(numpy.__version__)"  # 1.19.5
+```
+
+### Benchmark Script
+
+```python
+import numpy as np
+import time
+import tracemalloc
+
+for n in [500, 1000, 2000, 4000, 6000, 8000, 10000, 14000, 18000, 20000, 24000, 28000]:
+    try:
+        A = np.random.rand(n, n).astype(np.float64)
+        B = np.random.rand(n, n).astype(np.float64)
+        tracemalloc.start()
+        t = time.time()
+        C = np.dot(A, B)
+        wall = round(time.time() - t, 4)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        print(f"N={n:>6}  wall={wall}s  peak={peak/1024**2:.1f}MB  OK")
+        del A, B, C
+    except MemoryError:
+        print(f"N={n:>6}  FAILED — MemoryError")
+        break
+```
+
+### Results
+
+| Matrix Size (N) | Wall Time (s) | Peak Memory (MB) | Status |
+|---|---|---|---|
+| 500 | 0.004 | 1.9 | ✅ OK |
+| 1,000 | 0.030 | 7.6 | ✅ OK |
+| 2,000 | 0.229 | 30.5 | ✅ OK |
+| 4,000 | 1.898 | 122.1 | ✅ OK |
+| 6,000 | 6.309 | 274.7 | ✅ OK |
+| 8,000 | 14.466 | 488.3 | ✅ OK |
+| 10,000 | 27.455 | 763.0 | ✅ OK |
+| 14,000 | 74.186 | 1,495.4 | ✅ OK |
+| 18,000 | 160.061 | 2,471.9 | ✅ OK |
+| 20,000 | 218.74 | 3,051.8 | ✅ OK |
+| 24,000 | 371.49 | 4,394.5 | ✅ OK |
+| 28,000 | 741.36 | 5,981.4 | ✅ OK |
+| 32,000 | — | — | ❌ MemoryError |
+
+### Key Findings
+
+- Wall time scales as **O(N³)** — confirmed empirically (doubling N increases time ~8×).
+- Peak memory scales as **O(N²)** — doubling N increases memory ~4×.
+- NumPy automatically used **~8 cores in parallel** (CPU time was ~7.8× wall time), fully utilizing `lanec1`'s available cores.
+- **Maximum practical matrix size on `lanec1`: N = 28,000** (peak memory ~6 GB).
+- N = 32,000 fails with a `MemoryError` — matrices of this size require a chunked (tiled) multiplication approach that processes sub-blocks sequentially to stay within memory limits.
+
+---
+
+## Part 2: Sequence Alignment
+
+Pairwise sequence alignment is one of the most fundamental tasks in computational biology. This benchmark tests two classic dynamic programming algorithms — Needleman-Wunsch (global alignment) and Smith-Waterman (local alignment) — to determine how they scale with sequence length on `lanec1`.
+
+Both algorithms have **O(N²)** time and space complexity, where N is the sequence length.
+
+### Environment Setup
+
+```bash
+module load python36
+pip3 install biopython --user
+python3 -c "import Bio; print(Bio.__version__)"  # 1.79
+```
+
+### Algorithm Overview
+
+- **Needleman-Wunsch (global)**: aligns two sequences across their full length. Use this when comparing sequences expected to be similar end-to-end, such as orthologous genes across species.
+- **Smith-Waterman (local)**: finds the highest-scoring matching region between two sequences, ignoring the rest. Use this when searching for a conserved motif within a longer sequence, or comparing partially related sequences.
+
+### Benchmark Script
+
+```python
+import time
+import tracemalloc
+import random
+
+BASES = "ACGT"
+
+def random_sequence(length):
+    return "".join(random.choices(BASES, k=length))
+
+def needleman_wunsch(seq1, seq2, match=1, mismatch=-1, gap=-2):
+    n, m = len(seq1), len(seq2)
+    dp = [[0] * (m + 1) for _ in range(n + 1)]
+    for i in range(n + 1): dp[i][0] = i * gap
+    for j in range(m + 1): dp[0][j] = j * gap
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            score = match if seq1[i-1] == seq2[j-1] else mismatch
+            dp[i][j] = max(dp[i-1][j-1] + score, dp[i-1][j] + gap, dp[i][j-1] + gap)
+    return dp[n][m]
+
+def smith_waterman(seq1, seq2, match=1, mismatch=-1, gap=-2):
+    n, m = len(seq1), len(seq2)
+    dp = [[0] * (m + 1) for _ in range(n + 1)]
+    best = 0
+    for i in range(1, n + 1):
+        for j in range(1, m + 1):
+            score = match if seq1[i-1] == seq2[j-1] else mismatch
+            dp[i][j] = max(0, dp[i-1][j-1] + score, dp[i-1][j] + gap, dp[i][j-1] + gap)
+            if dp[i][j] > best: best = dp[i][j]
+    return best
+
+for length in [100, 500, 1000, 2000, 3000, 5000, 8000, 10000]:
+    seq1, seq2 = random_sequence(length), random_sequence(length)
+    for name, func in [("NW", needleman_wunsch), ("SW", smith_waterman)]:
+        tracemalloc.start()
+        t = time.time()
+        func(seq1, seq2)
+        wall = round(time.time() - t, 4)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        print(f"{name}  length={length}  wall={wall}s  peak={peak/1024**2:.1f}MB")
+```
+
+### Results
+
+| Length (bp) | Algorithm | Wall Time (s) | Peak Memory (MB) |
+|---|---|---|---|
+| 100 | Needleman-Wunsch | 0.021 | 0.4 |
+| 100 | Smith-Waterman | 0.013 | 0.1 |
+| 500 | Needleman-Wunsch | 0.738 | 8.6 |
+| 500 | Smith-Waterman | 0.532 | 2.0 |
+| 1,000 | Needleman-Wunsch | 3.476 | 34.5 |
+| 1,000 | Smith-Waterman | 2.587 | 7.7 |
+| 2,000 | Needleman-Wunsch | 14.673 | 137.6 |
+| 2,000 | Smith-Waterman | 10.997 | 30.7 |
+| 3,000 | Needleman-Wunsch | 33.992 | 309.4 |
+| 3,000 | Smith-Waterman | 25.558 | 68.9 |
+| 5,000 | Needleman-Wunsch | 95.374 | 859.0 |
+| 5,000 | Smith-Waterman | 72.944 | 191.2 |
+| 8,000 | Needleman-Wunsch | 249.321 | 2,198.4 |
+| 8,000 | Smith-Waterman | 189.032 | 489.0 |
+| 10,000 | Needleman-Wunsch | 396.631 | 3,434.6 |
+| 10,000 | Smith-Waterman | 297.938 | 763.8 |
+
+### Key Findings
+
+- Both algorithms scale as **O(N²)** in time and memory — confirmed empirically.
+- **Smith-Waterman is ~25% faster** than Needleman-Wunsch at all tested lengths.
+- **Smith-Waterman uses ~4.5× less memory** than Needleman-Wunsch (e.g., 764 MB vs. 3,435 MB at length 10,000).
+- Sequence alignment runs on a **single core** (CPU time ≈ wall time) — unlike matrix multiplication, it does not benefit from NumPy's multi-threading. Parallelization across sequences would yield significant speedups.
+- All lengths up to 10,000 bp completed successfully on `lanec1`.
+- Needleman-Wunsch at 10,000 bp uses 3.4 GB RAM, approaching `lanec1`'s practical limit for global alignment.
+- **Smith-Waterman is recommended** for large-scale alignment workloads on `lanec1`.
+
+---
+
+## Summary
+
+| Benchmark | lanec1 Limit | Scaling | Notes |
+|---|---|---|---|
+| Matrix multiplication | N = 28,000 | O(N³) time, O(N²) memory | N ≥ 32,000 requires chunked multiplication |
+| Sequence alignment (NW) | ~8,000 bp practical | O(N²) time and memory | High memory at large lengths |
+| Sequence alignment (SW) | ≥ 10,000 bp | O(N²) time and memory | Recommended for large inputs |
+
+For workloads that exceed these limits, consider using Bridge2 (128 cores, GPU nodes) via the Pittsburgh Supercomputing Center.
+
+---
+
+## References
+
+- NumPy documentation: <https://numpy.org/doc/>
+- Biopython documentation: <https://biopython.org/docs/>
+- Smith-Waterman algorithm: Smith, T.F. & Waterman, M.S. (1981). *Journal of Molecular Biology*, 147(1), 195–197.
+- Needleman-Wunsch algorithm: Needleman, S.B. & Wunsch, C.D. (1970). *Journal of Molecular Biology*, 48(3), 443–453.


### PR DESCRIPTION
This pull request adds benchmarking.md to docs/source/advanced/, documenting two computational benchmark: sequence alignment and matrix multiplication, run on lanec1 node. 